### PR TITLE
feat: implements release connections

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ export interface BackupReport {
     address: string;
   }
   
-  export interface Message {
+  export interface SMSMessage {
     id: number;
     date: string;
     sender: string;
@@ -36,13 +36,13 @@ export interface BackupReport {
     attachments: any[];
   }
   
-  export interface Chat {
+  export interface SMSChat {
     id: number;
     date: string;
     service: string;
     chatName: string;
     displayName: string;
-    messages: Message[];
+    messages: SMSMessage[];
   }
   
   export interface Contact {
@@ -71,15 +71,18 @@ export interface BackupReport {
   }
   
   declare function run(command: "backups.list"): Promise<BackupReport[]>;
-  declare function run(command: "messages.all", options: { backup: string }): Promise<Chat[]>;
+  declare function run(command: "messages.all", options: { backup: string }): Promise<SMSChat[]>;
   declare function run(command: "phone.calls", options: { backup: string }): Promise<Call[]>;
   declare function run(command: "phone.address_book", options: { backup: string }): Promise<Contact[]>;
   
   declare function configure(options: { base: string; id: string; password: string; }): Promise<void>;
+
+  declare function releaseConnections(options: { base: string; id: string; password: string; }): Promise<void>;
   
   export interface Ibackuptool {
     configure: typeof configure;
     run: typeof run;
+    releaseConnections: typeof releaseConnections;
   }
   
   declare const ibackuptool: Ibackuptool;

--- a/tools/backup-encrypted.js
+++ b/tools/backup-encrypted.js
@@ -10,6 +10,7 @@ const pbkdf2Hmac = require('pbkdf2-hmac')
 const bigintConversion = require('bigint-conversion')
 const sqlite3 = require('sqlite3').verbose()
 const filehash = require('ibackuptool/tools/util/backup_filehash')
+const { remove } = require('fs-extra')
 
 function aesDecrypt (keyString, input) {
   // eslint-disable-next-line new-cap
@@ -379,6 +380,7 @@ class BackupEncrypted {
     const dbs = Object.values(this.openDBs)
     await Promise.all(dbs.map((db) => closeDBConnection(db)))
     this.openDBs = {}
+    await remove(this.path)
   }
 }
 

--- a/tools/index.js
+++ b/tools/index.js
@@ -223,6 +223,27 @@ async function configure ({ base, id, password }) {
   __isBackupEncryptedConfigured__ = true
 }
 
+/**
+ * Releases all open database connections associated with the backup.
+ *
+ * It is essential to release the connections because, in some operating systems
+ * (like Windows), deleting the backup folder without releasing the connection
+ * can cause errors due to database files still being in use.
+ *
+ * @async
+ * @function
+ * @param {Object} params - Parameters required to initialize the backup connection.
+ * @param {string} params.base - The base path of the backup.
+ * @param {string} params.id - The identifier of the database.
+ * @param {string} params.password - The password to access the database.
+ *
+ * @returns {Promise<void>} A promise that resolves when all connections have been released.
+ */
+async function releaseConnections ({ base, id, password }) {
+  const backup = new Backup(base, id, password)
+  await backup.closeAllOpenDBs()
+}
+
 module.exports = {
   // Exported Libraries
   Backup,
@@ -255,5 +276,6 @@ module.exports = {
   },
 
   // mode management
-  configure
+  configure,
+  releaseConnections
 }


### PR DESCRIPTION
 Releases all open database connections associated with the backup.
 
 It is essential to release the connections because, in some operating systems
 (like Windows), deleting the backup folder without releasing the connection
 can cause errors due to database files still being in use.