### PR TITLE
feat: add functionality to filter WhatsApp messages starting from a s…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -95,7 +95,7 @@ export interface BackupReport {
   declare function run(command: "messages.all", options: { backup: string }): Promise<SMSChat[]>;
   declare function run(command: "phone.calls", options: { backup: string }): Promise<Call[]>;
   declare function run(command: "phone.address_book", options: { backup: string }): Promise<Contact[]>;
-  declare function run(command: "messages.whatsapp", options: { backup: string }): Promise<WhatsAppMessage[]>;
+  declare function run(command: "messages.whatsapp", options: { backup: string, fromUnixTimestamp?: number }): Promise<WhatsAppMessage[]>;
 
   
   declare function configure(options: { base: string; id: string; password: string; }): Promise<void>;

--- a/scripts/sandbox.js
+++ b/scripts/sandbox.js
@@ -2,6 +2,14 @@ const bt = require('../tools/index')
 const env = require('dotenv')
 const { join } = require('path')
 
+const unixTSFromToday = () => {
+  const currentDate = new Date()
+  const startOfDay = new Date(currentDate)
+  startOfDay.setHours(0, 0, 0, 0)
+  const unixTimestampStartOfDay = Math.floor(startOfDay.getTime() / 1000);
+  return unixTimestampStartOfDay
+}
+
 const main = async ({ BACKUP_PATH, APPLE_UDID, PASSWORD_BACKUP }) => {
   await bt.configure({
     base: BACKUP_PATH,
@@ -14,7 +22,7 @@ const main = async ({ BACKUP_PATH, APPLE_UDID, PASSWORD_BACKUP }) => {
     bt.run('messages.all', { backup: APPLE_UDID }),
     bt.run('phone.calls', { backup: APPLE_UDID }),
     bt.run('phone.address_book', { backup: APPLE_UDID }),
-    bt.run('messages.whatsapp', { backup: APPLE_UDID })
+    bt.run('messages.whatsapp', { backup: APPLE_UDID, fromUnixTimestamp: unixTSFromToday() })
   ])
 
   console.log(JSON.stringify({ report, messages, calls, addressBook, whatsappMessages }, null, 2))

--- a/tools/util/apple_timestamp.js
+++ b/tools/util/apple_timestamp.js
@@ -1,10 +1,11 @@
+const MAC_TO_UNIX_EPOCH_DIFF = 978307200 // Difference between Mac Absolute Time and UNIX epoch
+
 module.exports = {
-  parse: (field_name) => {
-    return `CASE WHEN (${field_name} > 1000000000) THEN datetime(${field_name} / 1000000000 + 978307200, 'unixepoch') 
-                 WHEN ${field_name} <> 0 THEN datetime((${field_name} + 978307200), 'unixepoch') 
-                 ELSE ${field_name} END`
-  },
-  /**
+  parse: (fieldName) => {
+    return `CASE WHEN (${fieldName} > 1000000000) THEN datetime(${fieldName} / 1000000000 + 978307200, 'unixepoch') 
+                 WHEN ${fieldName} <> 0 THEN datetime((${fieldName} + 978307200), 'unixepoch') 
+                 ELSE ${fieldName} END`
+  }, /**
    * Apple stores timestamps in Mac Absolute Time format,
    * which uses January 1, 2001, as its reference point. To convert this format to a UNIX timestamp,
    * add 978307200 seconds, representing the difference between the UNIX epoch (January 1, 1970)
@@ -18,8 +19,20 @@ module.exports = {
    * - The UNIX timestamp can then be converted to a human-readable date using standard time conversion functions.
    */
   toUnixTimeStamp: (macTime) => {
-    const MAC_TO_UNIX_EPOCH_DIFF = 978307200 // Difference between Mac Absolute Time and UNIX epoch
     const unixTimestamp = macTime + MAC_TO_UNIX_EPOCH_DIFF // Convert to UNIX timestamp
     return unixTimestamp
+  },
+  /**
+   * Converts a UNIX timestamp to Mac Absolute Time.
+   * The Mac Absolute Time epoch starts on January 1, 2001.
+   * UNIX epoch starts on January 1, 1970.
+   * The difference between these epochs is 978307200 seconds.
+   *
+   * @param {number} unixTimestamp - The UNIX timestamp to convert.
+   * @returns {number} The Mac Absolute Time.
+   */
+  toMacAbsoluteTime: (unixTimestamp) => {
+    const macTime = unixTimestamp - MAC_TO_UNIX_EPOCH_DIFF // Convert to Mac Absolute Time
+    return macTime
   }
 }


### PR DESCRIPTION
This pull request introduces the feature to filter WhatsApp messages starting from a specific date provided as a Unix timestamp. The implementation ensures that messages are retrieved based on the given timestamp, allowing users to easily fetch messages from a designated starting point. This functionality improves message handling and enables better control over the data retrieval process, aligning with the requirements of the ICS-444 ticket.



```ts
// Get today whatsapp messages
bt.run('messages.whatsapp', { backup: APPLE_UDID, fromUnixTimestamp: unixTSFromToday() })

// Get all whatsapp messages in backup
bt.run('messages.whatsapp', { backup: APPLE_UDID })
```

