### PR TITLE
fix: ICS-495 remove backup instance when release connection

### DIFF
--- a/tools/backup-encrypted.js
+++ b/tools/backup-encrypted.js
@@ -61,6 +61,10 @@ class BackupEncrypted {
     BackupEncrypted.instance = this
   }
 
+  static destroy () {
+    BackupEncrypted.instance = null
+  }
+
   async load () {
     this.manifest = await this.readManifest()
     const backupKeyBag = this.manifest['BackupKeyBag']

--- a/tools/index.js
+++ b/tools/index.js
@@ -242,6 +242,7 @@ async function configure ({ base, id, password }) {
 async function releaseConnections ({ base, id, password }) {
   const backup = new Backup(base, id, password)
   await backup.closeAllOpenDBs()
+  Backup.destroy()
 }
 
 module.exports = {


### PR DESCRIPTION
The problem with multiple backups is that the singleton instance remains alive throughout the application's lifecycle. For each backup, it should be removed when the connection is released.







